### PR TITLE
Allow customization of the logger with NewWith

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.29
           working-directory: emf 

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# IDE artifacts
 .idea/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 Go implementation of AWS CloudWatch [Embedded Metric Format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html)
 
 It's aim is to simplify reporting metrics to CloudWatch:
+
 - using EMF avoids additional HTTP API calls to CloudWatch as metrics are logged in JSON format to stdout
 - no need for additional dependencies in your services (or mocks in tests) to report metrics from inside your code
 - built in support for default dimensions and properties for Lambda functions
@@ -14,6 +15,7 @@ It's aim is to simplify reporting metrics to CloudWatch:
 Supports namespaces, setting dimensions and properties as well as different contexts (at least partially).
 
 Usage:
+
 ```
 emf.New().Namespace("mtg").Metric("totalWins", 1500).Log()
 
@@ -21,12 +23,13 @@ emf.New().Dimension("colour", "red").
     MetricAs("gameLength", 2, emf.Seconds).Log()
 
 emf.New().DimensionSet(
-        emf.NewDimension("format", "edh"), 
+        emf.NewDimension("format", "edh"),
         emf.NewDimension("commander", "Muldrotha")).
     MetricAs("wins", 1499, emf.Count).Log()
 ```
 
 You may also use the lib together with `defer`.
+
 ```
 m := emf.New() // sets up whatever you fancy here
 defer m.Log()
@@ -34,7 +37,16 @@ defer m.Log()
 // any reporting metrics calls
 ```
 
+Customizing the logger:
+```
+emf.NewWith(
+    emf.WithWriter(os.Stderr), // Log to stderr.
+    emf.WithTimestamp(time.Now().Add(-time.Hour)), // Record past metrics.
+)
+```
+
 Functions for reporting metrics:
+
 ```
 func Metric(name string, value int)
 func Metrics(m map[string]int)
@@ -48,6 +60,7 @@ func MetricsFloatAs(m map[string]float64, unit MetricUnit)
 ```
 
 Functions for setting up dimensions:
+
 ```
 func Dimension(key, value string)
 func DimensionSet(dimensions ...Dimension) // use `func NewDimension` for creating one

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ defer m.Log()
 
 Customizing the logger:
 ```
-emf.NewWith(
+emf.New(
     emf.WithWriter(os.Stderr), // Log to stderr.
     emf.WithTimestamp(time.Now().Add(-time.Hour)), // Record past metrics.
 )

--- a/emf/emf.go
+++ b/emf/emf.go
@@ -1,4 +1,4 @@
-// Spec available here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+// Package emf implements the spec available here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
 package emf
 
 // Metadata struct as defined in AWS Embedded Metrics Format spec.

--- a/emf/logger.go
+++ b/emf/logger.go
@@ -24,18 +24,18 @@ type Context struct {
 	values          map[string]interface{}
 }
 
-// NewOption defines a function that can be used to customize a logger.
-type NewOption func(l *Logger)
+// LoggerOption defines a function that can be used to customize a logger.
+type LoggerOption func(l *Logger)
 
 // WithWriter customizes the writer used by a logger.
-func WithWriter(w io.Writer) NewOption {
+func WithWriter(w io.Writer) LoggerOption {
 	return func(l *Logger) {
 		l.out = w
 	}
 }
 
 // WithTimestamp customizes the timestamp used by a logger.
-func WithTimestamp(t time.Time) NewOption {
+func WithTimestamp(t time.Time) LoggerOption {
 	return func(l *Logger) {
 		l.timestamp = t.UnixNano() / int64(time.Millisecond)
 	}
@@ -46,7 +46,7 @@ func WithTimestamp(t time.Time) NewOption {
 // - Context based on Lambda environment variables.
 // - Timestamp set to the time when NewWith was called.
 // Specify NewOptions to customize the logger.
-func NewWith(opts ...NewOption) *Logger {
+func New(opts ...LoggerOption) *Logger {
 	values := make(map[string]interface{})
 
 	// set default properties for lambda function
@@ -78,18 +78,6 @@ func NewWith(opts ...NewOption) *Logger {
 	}
 
 	return l
-}
-
-// New creates logger printing to os.Stdout, perfect for Lambda functions.
-// Deprecated: use NewWith instead.
-func New() *Logger {
-	return NewWith(WithWriter(os.Stdout))
-}
-
-// NewFor creates logger printing to any suitable writer.
-// Deprecated: use NewWith and WithWriter instead.
-func NewFor(out io.Writer) *Logger {
-	return NewWith(WithWriter(out))
 }
 
 // Dimension helps builds DimensionSet.

--- a/emf/logger.go
+++ b/emf/logger.go
@@ -44,7 +44,7 @@ func WithTimestamp(t time.Time) LoggerOption {
 // New creates logger with reasonable defaults for Lambda functions:
 // - Prints to os.Stdout.
 // - Context based on Lambda environment variables.
-// - Timestamp set to the time when NewWith was called.
+// - Timestamp set to the time when New was called.
 // Specify LoggerOptions to customize the logger.
 func New(opts ...LoggerOption) *Logger {
 	values := make(map[string]interface{})

--- a/emf/logger.go
+++ b/emf/logger.go
@@ -41,11 +41,11 @@ func WithTimestamp(t time.Time) LoggerOption {
 	}
 }
 
-// NewWith creates logger with reasonable defaults for Lambda functions:
+// New creates logger with reasonable defaults for Lambda functions:
 // - Prints to os.Stdout.
 // - Context based on Lambda environment variables.
 // - Timestamp set to the time when NewWith was called.
-// Specify NewOptions to customize the logger.
+// Specify LoggerOptions to customize the logger.
 func New(opts ...LoggerOption) *Logger {
 	values := make(map[string]interface{})
 

--- a/emf/logger_internal_test.go
+++ b/emf/logger_internal_test.go
@@ -1,0 +1,71 @@
+package emf
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestNewWith(t *testing.T) {
+	tcs := []struct {
+		name     string
+		opts     []NewOption
+		expected *Logger
+	}{
+		{
+			name: "default",
+			expected: &Logger{
+				out:       os.Stdout,
+				timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+			},
+		},
+		{
+			name: "with options",
+			opts: []NewOption{
+				WithWriter(os.Stderr),
+				WithTimestamp(time.Now().Add(time.Hour)),
+			},
+			expected: &Logger{
+				out:       os.Stderr,
+				timestamp: time.Now().Add(time.Hour).UnixNano() / int64(time.Millisecond),
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := NewWith(tc.opts...)
+			if err := loggersEqual(actual, tc.expected); err != nil {
+				t.Errorf("logger does not match: %v", err)
+			}
+		})
+	}
+
+}
+
+// loggersEqual returns a non-nil error if the loggers do not match.
+// Currently it only checks that the loggers' output writer and timestamp match.
+// TODO: expand the checks here as more NewOptions are added.
+func loggersEqual(actual, expected *Logger) error {
+	if actual.out != expected.out {
+		return fmt.Errorf("output does not match")
+	}
+
+	if err := approxInt64(actual.timestamp, expected.timestamp, 100 /* ms */); err != nil {
+		return fmt.Errorf("timestamp %v", err)
+	}
+
+	return nil
+}
+
+func approxInt64(actual, expected, tolerance int64) error {
+	diff := expected - actual
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > tolerance {
+		return fmt.Errorf("value %v is out of tolerance %v±%v", actual, expected, tolerance)
+	}
+	return nil
+}

--- a/emf/logger_internal_test.go
+++ b/emf/logger_internal_test.go
@@ -46,7 +46,6 @@ func TestNew(t *testing.T) {
 
 // loggersEqual returns a non-nil error if the loggers do not match.
 // Currently it only checks that the loggers' output writer and timestamp match.
-// TODO: expand the checks here as more NewOptions are added.
 func loggersEqual(actual, expected *Logger) error {
 	if actual.out != expected.out {
 		return fmt.Errorf("output does not match")

--- a/emf/logger_internal_test.go
+++ b/emf/logger_internal_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 )
 
-func TestNewWith(t *testing.T) {
+func TestNew(t *testing.T) {
 	tcs := []struct {
 		name     string
-		opts     []NewOption
+		opts     []LoggerOption
 		expected *Logger
 	}{
 		{
@@ -22,7 +22,7 @@ func TestNewWith(t *testing.T) {
 		},
 		{
 			name: "with options",
-			opts: []NewOption{
+			opts: []LoggerOption{
 				WithWriter(os.Stderr),
 				WithTimestamp(time.Now().Add(time.Hour)),
 			},
@@ -35,7 +35,7 @@ func TestNewWith(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := NewWith(tc.opts...)
+			actual := New(tc.opts...)
 			if err := loggersEqual(actual, tc.expected); err != nil {
 				t.Errorf("logger does not match: %v", err)
 			}

--- a/emf/logger_test.go
+++ b/emf/logger_test.go
@@ -181,7 +181,7 @@ func TestEmf(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			logger := emf.NewFor(&buf)
+			logger := emf.New(emf.WithWriter(&buf))
 			tc.given(logger)
 			logger.Log()
 
@@ -196,7 +196,7 @@ func TestEmf(t *testing.T) {
 
 	t.Run("no metrics set", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := emf.NewFor(&buf)
+		logger := emf.New(emf.WithWriter(&buf))
 		logger.Log()
 
 		if buf.String() != "" {
@@ -206,7 +206,7 @@ func TestEmf(t *testing.T) {
 
 	t.Run("new context, no metrics set", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := emf.NewFor(&buf)
+		logger := emf.New(emf.WithWriter(&buf))
 		logger.NewContext().Namespace("galaxy")
 		logger.Log()
 


### PR DESCRIPTION
This PR primarily addresses #3 by allowing for the timestamp to be customized when creating the logger. Instead of bumping the MV or creating a breaking change I introduced a new method, `NewWith`, which uses functional options to customize the logger. `New` and `NewFor` were updated to simply call `NewWith` with the correct values to keep their output consistent.

The PR also:
1. Deprecates `New` and `NewFor`. I could see an argument to NOT deprecate `New` so let me know if you'd like that designation removed.
2. Added a small comment in `.gitignore` to call out what `.idea/` is. IMO this line shouldn't even be there and should instead be added to the developer's local `.gitignore` but not a hill I'm willing to die on :)
3. Updated the readme and formatted it with `prettier`.
4. Added tests for `NewWith`.
5. Added / updated some doc comments so golint would stop complaining (as much).