### PR TITLE
Allow user to not use default dimensions

### DIFF
--- a/emf/logger_test.go
+++ b/emf/logger_test.go
@@ -216,6 +216,204 @@ func TestEmf(t *testing.T) {
 	})
 }
 
+
+func TestEmfNoDefaultDimensions(t *testing.T) {
+	tcs := []struct {
+		name     string
+		env      map[string]string
+		given    func(logger *emf.Logger)
+		expected string
+	}{
+		{
+			name: "default namespace, int metric",
+			given: func(logger *emf.Logger) {
+				logger.Metric("foo", 33)
+			},
+			expected: "testdata/1.json",
+		},
+		{
+			name: "default namespace, float metric",
+			given: func(logger *emf.Logger) {
+				logger.MetricFloat("foo", 33.66)
+			},
+			expected: "testdata/2.json",
+		},
+		{
+			name: "custom namespace, int and float metrics",
+			given: func(logger *emf.Logger) {
+				logger.Namespace("galaxy").MetricFloat("foo", 33.66).Metric("bar", 666)
+			},
+			expected: "testdata/3.json",
+		},
+		{
+			name: "custom namespace, int and float metrics, custom units",
+			given: func(logger *emf.Logger) {
+				logger.Namespace("galaxy").
+					MetricFloatAs("foo", 33.66, emf.Milliseconds).
+					MetricAs("bar", 666, emf.Count)
+			},
+			expected: "testdata/4.json",
+		},
+		{
+			name: "new context, default namespace, int and float metrics, custom units",
+			given: func(logger *emf.Logger) {
+				logger.NewContext().
+					MetricFloatAs("foo", 33.66, emf.Milliseconds).
+					MetricAs("bar", 666, emf.Count)
+			},
+			expected: "testdata/5.json",
+		},
+		{
+			name: "new context, custom namespace, int and float metrics, custom units",
+			given: func(logger *emf.Logger) {
+				logger.NewContext().Namespace("galaxy").
+					MetricFloatAs("foo", 33.66, emf.Bits).
+					MetricAs("bar", 666, emf.BytesSecond)
+			},
+			expected: "testdata/6.json",
+		},
+		{
+			name: "default and custom contexts, different metrics names",
+			given: func(logger *emf.Logger) {
+				logger.NewContext().MetricFloatAs("foo", 33.66, emf.Bits)
+				logger.MetricAs("bar", 666, emf.BytesSecond)
+			},
+			expected: "testdata/7.json",
+		},
+		{
+			name: "set property",
+			given: func(logger *emf.Logger) {
+				logger.Property("aaa", "666").Metric("foo", 33)
+			},
+			expected: "testdata/8.json",
+		},
+
+		{
+			name: "not sampled trace",
+			env: map[string]string{
+				"_X_AMZN_TRACE_ID": "foo",
+			},
+			given: func(logger *emf.Logger) {
+				logger.Metric("foo", 33)
+			},
+			expected: "testdata/10.json",
+		},
+		{
+			name: "one dimension",
+			given: func(logger *emf.Logger) {
+				logger.Dimension("a", "b").Metric("c", 11)
+			},
+			expected: "testdata/12.json",
+		},
+		{
+			name: "two dimensions",
+			given: func(logger *emf.Logger) {
+				logger.Dimension("a", "b").Dimension("o", "p").Metric("c", 11)
+			},
+			expected: "testdata/13.json",
+		},
+		{
+			name: "one dimension set",
+			given: func(logger *emf.Logger) {
+				logger.
+					DimensionSet(
+						emf.NewDimension("a", "b"),
+						emf.NewDimension("o", "p")).
+					Metric("c", 11)
+			},
+			expected: "testdata/14.json",
+		},
+		{
+			name: "two dimension sets",
+			given: func(logger *emf.Logger) {
+				logger.
+					DimensionSet(
+						emf.NewDimension("a", "b"),
+						emf.NewDimension("c", "d")).
+					DimensionSet(
+						emf.NewDimension("1", "2"),
+						emf.NewDimension("3", "4")).
+					Metric("foo", 22)
+			},
+			expected: "testdata/15.json",
+		},
+		{
+			name: "default and custom contexts, multiple dimensions/dimension sets",
+			given: func(logger *emf.Logger) {
+				logger.NewContext().
+					Dimension("CC", "DD").
+					DimensionSet(
+						emf.NewDimension("gg", "hh"),
+						emf.NewDimension("kk", "jj")).
+					MetricFloatAs("foo", 33.66, emf.Bits)
+				logger.
+					Dimension("AA", "BB").
+					DimensionSet(
+						emf.NewDimension("ww", "ee"),
+						emf.NewDimension("rr", "tt")).
+					MetricAs("bar", 666, emf.BytesSecond)
+			},
+			expected: "testdata/16.json",
+		},
+		{
+			name: "default properties for lambda are ignored",
+			env: map[string]string{
+				"AWS_LAMBDA_FUNCTION_NAME":        "some-func-name",
+				"AWS_EXECUTION_ENV":               "golang",
+				"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "128",
+				"AWS_LAMBDA_FUNCTION_VERSION":     "1",
+				"AWS_LAMBDA_LOG_STREAM_NAME":      "log/stream",
+			},
+			given: func(logger *emf.Logger) {
+				logger.Metric("foo", 33)
+			},
+			expected: "testdata/17.json",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.env) > 0 {
+				defer unsetenv(t, tc.env)
+				setenv(t, tc.env)
+			}
+
+			var buf bytes.Buffer
+			logger := emf.NewWithoutDefaultDimensions(emf.WithWriter(&buf))
+			tc.given(logger)
+			logger.Log()
+
+			f, err := ioutil.ReadFile(tc.expected)
+			if err != nil {
+				t.Fatal("unable to read file with expected json")
+			}
+
+			jsonassert.New(t).Assertf(buf.String(), string(f))
+		})
+	}
+
+	t.Run("no metrics set", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := emf.New(emf.WithWriter(&buf))
+		logger.Log()
+
+		if buf.String() != "" {
+			t.Error("Buffer not empty")
+		}
+	})
+
+	t.Run("new context, no metrics set", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := emf.New(emf.WithWriter(&buf))
+		logger.NewContext().Namespace("galaxy")
+		logger.Log()
+
+		if buf.String() != "" {
+			t.Error("Buffer not empty")
+		}
+	})
+}
+
 func setenv(t *testing.T, env map[string]string) {
 	for k, v := range env {
 		err := os.Setenv(k, v)

--- a/emf/logger_test.go
+++ b/emf/logger_test.go
@@ -216,7 +216,6 @@ func TestEmf(t *testing.T) {
 	})
 }
 
-
 func TestEmfNoDefaultDimensions(t *testing.T) {
 	tcs := []struct {
 		name     string

--- a/emf/testdata/17.json
+++ b/emf/testdata/17.json
@@ -1,0 +1,18 @@
+{
+  "_aws": {
+    "Timestamp": "<<PRESENCE>>",
+    "CloudWatchMetrics": [
+      {
+        "Metrics": [
+          {
+            "Name": "foo",
+            "Unit": "None"
+          }
+        ],
+        "Namespace": "aws-embedded-metrics",
+        "Dimensions": null
+      }
+    ]
+  },
+  "foo": 33
+}


### PR DESCRIPTION
The library as is always creates default dimensions ServiceType and ServiceName which are based on environment variables.

If you add custom dimensions those don’t replace the default dimensions.

Let me provide an example. We have a metric which measures the major API version we receive when another service calls our Lambda based service. So the dimension is `majorVersion` and the value is `1`  (i.e. a count).

What the library now does is it will persist this metric twice, once with the custom dimension (`majorVersion`), once with the default dimensions mentioned above. The latter is not a useful piece of information as the dimension is critical for the semantics of the metric.

If you have a metric with no dimensions, the library will instead persist it with the default dimensions mentioned above, which will mess up your existing alerts and dashboards.

In order to be able to use the library without any default dimensions we have added `NewWithoutDefaultDimensions` which will allow the user to use the library without those default dimensions and also without the tracking specific logic.

We have also adapted the tests accordingly, albeit not in the most elegant way imaginable.