### PR TITLE
Add the option to set log group as per https://docs.aws.amazon.com/Am…

### DIFF
--- a/emf/emf.go
+++ b/emf/emf.go
@@ -3,8 +3,9 @@ package emf
 
 // Metadata struct as defined in AWS Embedded Metrics Format spec.
 type Metadata struct {
-	Timestamp int64             `json:"Timestamp"`
-	Metrics   []MetricDirective `json:"CloudWatchMetrics"`
+	Timestamp    int64             `json:"Timestamp"`
+	Metrics      []MetricDirective `json:"CloudWatchMetrics"`
+	LogGroupName string            `json:"LogGroupName,omitempty"`
 }
 
 // MetricDirective struct as defined in AWS Embedded Metrics Format spec.

--- a/emf/logger.go
+++ b/emf/logger.go
@@ -17,6 +17,7 @@ type Logger struct {
 	contexts          []*Context
 	values            map[string]interface{}
 	withoutDimensions bool
+	logGroupName      string
 }
 
 // Context gives ability to add another MetricDirective section for Logger.
@@ -46,6 +47,13 @@ func WithTimestamp(t time.Time) LoggerOption {
 func WithoutDimensions() LoggerOption {
 	return func(l *Logger) {
 		l.withoutDimensions = true
+	}
+}
+
+// WithLogGroup sets the log group when ingesting metrics into Cloudwatch Logging Agent.
+func WithLogGroup(logGroup string) LoggerOption {
+	return func(l *Logger) {
+		l.logGroupName = logGroup
 	}
 }
 
@@ -202,8 +210,9 @@ func (l *Logger) Log() {
 	}
 
 	l.values["_aws"] = Metadata{
-		Timestamp: l.timestamp,
-		Metrics:   metrics,
+		Timestamp:    l.timestamp,
+		Metrics:      metrics,
+		LogGroupName: l.logGroupName,
 	}
 	buf, _ := json.Marshal(l.values)
 	_, _ = fmt.Fprintln(l.out, string(buf))

--- a/emf/logger_test.go
+++ b/emf/logger_test.go
@@ -189,6 +189,16 @@ func TestEmf(t *testing.T) {
 			},
 			expected: "testdata/17.json",
 		},
+		{
+			name: "with log group",
+			new: func(buf *bytes.Buffer) *emf.Logger {
+				return emf.New(emf.WithLogGroup("test_log_group"), emf.WithWriter(buf))
+			},
+			given: func(logger *emf.Logger) {
+				logger.Metric("foo", 33)
+			},
+			expected: "testdata/18.json",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/emf/testdata/18.json
+++ b/emf/testdata/18.json
@@ -1,0 +1,19 @@
+{
+  "_aws": {
+    "Timestamp": "<<PRESENCE>>",
+    "LogGroupName": "test_log_group",
+    "CloudWatchMetrics": [
+      {
+        "Metrics": [
+          {
+            "Name": "foo",
+            "Unit": "None"
+          }
+        ],
+        "Namespace": "aws-embedded-metrics",
+        "Dimensions": null
+      }
+    ]
+  },
+  "foo": 33
+}


### PR DESCRIPTION
### Provide ability to set Log Group
When using the Amazon Cloudwatch Agent to ship logs in EMF format, it requires that a "LogGroupName" kvp be set under the "_aws" dictionary. 

This is so that the Cloudwatch Logs Agent can know who the the data is coming from since it can ingest remotely (over TCP/UDP) from various processes.

https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_CloudWatch_Agent.html
