### PR TITLE
Add access to the EMF data as map[string]interface{}

### DIFF
--- a/emf/logger.go
+++ b/emf/logger.go
@@ -195,6 +195,22 @@ func (l *Logger) MetricsFloatAs(m map[string]float64, unit MetricUnit) *Logger {
 
 // Log prints all Contexts and metric values to chosen output in Embedded Metric Format.
 func (l *Logger) Log() {
+	emf := l.build()
+	if len(emf) == 0 {
+		return
+	}
+
+	buf, _ := json.Marshal(emf)
+	_, _ = fmt.Fprintln(l.out, string(buf))
+}
+
+// Build constructs the EMF structure as a map that includes all Contexts and metric values.
+// The map is arranged according to Embedded Metric Format.
+func (l *Logger) Build() map[string]interface{} {
+	return l.build()
+}
+
+func (l *Logger) build() map[string]interface{} {
 	var metrics []MetricDirective
 	if len(l.defaultContext.metricDirective.Metrics) > 0 {
 		metrics = append(metrics, l.defaultContext.metricDirective)
@@ -206,7 +222,7 @@ func (l *Logger) Log() {
 	}
 
 	if len(metrics) == 0 {
-		return
+		return map[string]interface{}{}
 	}
 
 	l.values["_aws"] = Metadata{
@@ -214,8 +230,8 @@ func (l *Logger) Log() {
 		Metrics:      metrics,
 		LogGroupName: l.logGroupName,
 	}
-	buf, _ := json.Marshal(l.values)
-	_, _ = fmt.Fprintln(l.out, string(buf))
+
+	return l.values
 }
 
 // NewContext creates new context for given logger.

--- a/emf/logger_test.go
+++ b/emf/logger_test.go
@@ -2,6 +2,7 @@ package emf_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -225,6 +226,11 @@ func TestEmf(t *testing.T) {
 			}
 
 			jsonassert.New(t).Assertf(buf.String(), string(f))
+
+			// test Build() to generate the same structure as Log()
+			metrics := logger.Build()
+			metricsJson, _ := json.Marshal(metrics)
+			jsonassert.New(t).Assertf(string(metricsJson), string(f))
 		})
 	}
 
@@ -238,6 +244,14 @@ func TestEmf(t *testing.T) {
 		}
 	})
 
+	t.Run("no metrics set, with build", func(t *testing.T) {
+		m := emf.New().Build()
+
+		if len(m) > 0 {
+			t.Error("Map not empty")
+		}
+	})
+
 	t.Run("new context, no metrics set", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := emf.New(emf.WithWriter(&buf))
@@ -246,6 +260,16 @@ func TestEmf(t *testing.T) {
 
 		if buf.String() != "" {
 			t.Error("Buffer not empty")
+		}
+	})
+
+	t.Run("new context, no metrics set, with build", func(t *testing.T) {
+		logger := emf.New()
+		logger.NewContext().Namespace("galaxy")
+		m := logger.Build()
+
+		if len(m) > 0 {
+			t.Error("Map not empty")
 		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/prozz/aws-embedded-metrics-golang
 
-go 1.14
+go 1.20
 
 require github.com/kinbiko/jsonassert v1.1.1


### PR DESCRIPTION
### Provide ability to retrieve the raw EMF data

In order to include the `"_aws"` as a named attribute in our logging system we would like to create it with your library (excellent and clean), but then apply it with our normal setup.

Example with our current solution and embedding some statistics in our logs as named value pairs:
```
	log.WithContext(ctx).
		With("duration_ms", time.Since(start).Milliseconds()).
		With("count", len(my_arr)).
		Debug("Items found")
```

To add EMF with this lib we would like to add a function for EMF that is plug and play with current logging interface, like:
```
	metrics := emf.New().
		Namespace("TLSDiscoveryNamespace").
		Dimension("dim", "example").
		MetricAs("counter", 1, emf.Count).
		Build()

	// The Build() exposes the map that is normally marshalled and makes it easy to integrate
	log.WithContext(ctx).WithMetrics(metrics).Info("items found")
```

With current implementation we would need to unmarshal the bytes from log:
```
	var buf bytes.Buffer
	metrics := emf.New(&buf).
		Namespace("TLSDiscoveryNamespace").
		Dimension("dim", "example").
		MetricAs("counter", 1, emf.Count).
		Log()

	// WithMetrics unmarshal the bytes to map in order to add the _aws metrics on proper level
	log.WithContext(ctx).WithMetrics(buf.Bytes()).Info("items found")
```

I see this mainly as a convenience method, but we would really love to see it, or something similar, included.